### PR TITLE
Optimize Go's mod cache usage across GH Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+go.mod text eol=lf
+go.sum text eol=lf

--- a/.github/workflows/build-k0s.yml
+++ b/.github/workflows/build-k0s.yml
@@ -80,9 +80,9 @@ jobs:
       - name: "Cache :: GOMODCACHE"
         uses: actions/cache@v4
         with:
-          key: build-k0s-${{ inputs.target-os }}-${{ inputs.target-arch }}-gomodcache-${{ hashFiles('go.sum') }}
-          path: |
-            build/cache/go/mod
+          key: build-k0s-gomodcache-${{ hashFiles('go.sum') }}
+          path: build/cache/go/mod
+          enableCrossOsArchive: true
 
       - name: "Build :: k0s"
         run: |

--- a/.github/workflows/check-network.yaml
+++ b/.github/workflows/check-network.yaml
@@ -89,11 +89,11 @@ jobs:
           path: |
             build/cache/go/build
       - name: Cache GOMODCACHE
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
-          key: ${{ runner.os }}-build-gomodcache-linux-${{ hashFiles('go.sum') }}
-          path: |
-            build/cache/go/mod
+          key: build-k0s-gomodcache-${{ hashFiles('go.sum') }}
+          path: build/cache/go/mod
+          enableCrossOsArchive: true
 
       - name: Build k0s Binary
         id: k0s_build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -182,8 +182,8 @@ jobs:
         uses: actions/cache@v4
         with:
           key: unittests-k0s-gomodcache-${{ hashFiles('go.sum') }}
-          path: |
-            build/cache/go/mod
+          path: build/cache/go/mod
+          enableCrossOsArchive: true
 
       - name: Run unit tests
         run: make check-unit $UNITTEST_EXTRA_ARGS


### PR DESCRIPTION
## Description

In order to be able to share caches between operating systems, you have to set enableCrossOsArchive to true, and the cache paths have to be identical (which was already the case).

Also make sure that go.mod/go.sum files always use LF line endings, even on Windows. Otherwise the cache keys would be different.

See: https://github.com/actions/cache/blob/v4.2.0/tips-and-workarounds.md#cross-os-cache

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist:

- [ ] My code follows the style [guidelines](https://github.com/k0sproject/k0s/blob/main/docs/contributors/overview.md) of this project 
- [ ] My commit messages are [signed-off](https://github.com/k0sproject/k0s/blob/main/docs/contributors/github_workflow.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings