### PR TITLE
Fix docs to match style guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,12 @@
 # Quick Start Guide
 
- On completion of the Quick Start you will have a full Kubernetes cluster with a single node that includes both the controller and the worker. Such a setup is ideal for environments that do not require high-availability and multiple nodes.
+Completing this Quick Start results in a single-node Kubernetes cluster that includes both the controller and worker roles. This setup suits environments that do not require high availability or multiple nodes.
 
 ## Prerequisites
 
 **Note**: Before proceeding, make sure to review the [System Requirements](system-requirements.md).
 
-Though the Quick Start material is written for Debian/Ubuntu, you can use it for any Linux distro that is running either a Systemd or OpenRC init system.
+Although the steps are written for Debian/Ubuntu, they work on any Linux distribution that uses Systemd or OpenRC.
 
 ## Install k0s
 
@@ -18,7 +18,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
     ```
 
-    Alternatively you can download it from the [releases page.](https://github.com/k0sproject/k0s/releases/latest) This is required for airgapped environments.
+    Alternatively, download it from the [releases page.](https://github.com/k0sproject/k0s/releases/latest) This approach is required in airgapped environments.
 
 2. Install k0s as a service
 
@@ -31,7 +31,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     ```
 
     NOTE:
-    The `--single` option will disable features needed for multi-node clusters, so you will not be able to extend this cluster. If you want to be able to extend the cluster in the future, you should use:
+    The `--single` option disables features needed for multi-node clusters, so the cluster cannot be extended. To enable expansion later, use:
 
     ``` shell
     sudo k0s install controller --enable-worker --no-taints
@@ -66,7 +66,7 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
 
 4. Check service, logs and k0s status
 
-    To get general information about your k0s instance's status, run:
+    To get general information about the k0s instance status, run:
 
     ```shell
     $ sudo k0s status
@@ -77,11 +77,11 @@ Though the Quick Start material is written for Debian/Ubuntu, you can use it for
     Init System: linux-systemd
     ```
 
-5. Access your cluster using kubectl
+5. Access the cluster using kubectl
 
     **Note**: k0s includes the Kubernetes command-line tool *kubectl*.
 
-    Use kubectl to deploy your application or to check your node status:
+    Use kubectl to deploy applications or check node status:
 
     ```shell
     $ sudo k0s kubectl get nodes
@@ -109,7 +109,7 @@ The removal of k0s is a two-step process.
 
 3. Reboot the system.
 
-    A few small k0s fragments persist even after the reset (for example, iptables). As such, you should initiate a reboot after the running of the `k0s reset` command.
+    A few small k0s fragments persist even after the reset, such as iptables rules. Reboot the machine after running `k0s reset`.
 
 ## Next Steps
 

--- a/docs/podsecurity.md
+++ b/docs/podsecurity.md
@@ -3,7 +3,7 @@
 Since Pod Security Policies have been removed in Kubernetes v1.25, Kubernetes
 offers [Pod Security Standards] – a new way to enhance cluster security.
 
-To enable PSS in k0s you need to create an admission controller config file:
+To enable PSS in k0s, create an admission controller configuration file:
 
     ```yaml
     apiVersion: apiserver.config.k8s.io/v1

--- a/docs/troubleshooting/certificate-authorities.md
+++ b/docs/troubleshooting/certificate-authorities.md
@@ -29,8 +29,7 @@ to all nodes, and then bringing the cluster back online:
 
 2. Stop k0s on all worker and controller nodes. All the instructions below
    assume that all k0s nodes are using the default data directory
-   `/var/lib/k0s`. Please adjust accordingly if you're using a different data
-   directory path.
+   `/var/lib/k0s`. Adjust the path if a different data directory is used.
 
 3. Delete the Kubernetes CA and SA key pair files from the all the controller
    data directories:
@@ -49,7 +48,7 @@ to all nodes, and then bringing the cluster back online:
 
 4. Choose one controller as the "first" one. Restart k0s on the first
    controller. If this controller is running with the `--enable-worker` flag,
-   you should **reboot the machine** instead. This will ensure that all
+   **reboot the machine** instead. This ensures that all
    processes and pods will be cleanly restarted. After the restart, k0s will
    have regenerated a new Kubernetes CA and SA key pair.
 
@@ -83,8 +82,7 @@ to all nodes, and then bringing the cluster back online:
    `/var/lib/k0s/kubelet-bootstrap.conf`. Then reboot the machine.
 
 7. When all workers are back online, the `kubelet-bootstrap.conf` files can be
-   safely removed from the workers. You can also invalidate the token so you
-   don't have to wait for it to expire: Use [`k0s token list --role
+   safely removed from the workers. The token can be invalidated without waiting for expiration: Use [`k0s token list --role
    worker`](../cli/k0s_token_list.md) to list all tokens and [`k0s token
    invalidate <token-id>`](../cli/k0s_token_invalidate.md) to invalidate them immediately.
 

--- a/docs/troubleshooting/logs.md
+++ b/docs/troubleshooting/logs.md
@@ -13,8 +13,8 @@ Jul 08 08:46:26 worker-kppzr-lls2q k0s[1766]: time="2024-07-08 08:46:26" level=i
 
 ### systemd based setups
 
-SystemD uses journal log system for all logs. This means that you can access k0s and all the sub-component logs using `journalctl`. For example if you are interested in kubelet logs, you can run something like `journalctl -u k0sworker | grep component=kubelet`.
+SystemD stores logs in the journal. Access k0s and all component logs using `journalctl`. For example, to view kubelet logs, run `journalctl -u k0sworker | grep component=kubelet`.
 
 ### openRC based setups
 
-openRC stores logs of services in `/var/log/k0sworker.log`. Again, if you're interested in specific component logs you cat run something like `grep component=kubelet /var/log/k0s.log`.
+openRC stores service logs in `/var/log/k0sworker.log`. To view a specific component log, run `grep component=kubelet /var/log/k0s.log`.

--- a/docs/troubleshooting/support-dump.md
+++ b/docs/troubleshooting/support-dump.md
@@ -3,23 +3,23 @@
 In many cases, especially when looking for [commercial support](../commercial-support.md) there's a need for share the cluster state with other people.
 While one could always give access to the live cluster that is not always desired nor even possible.
 
-For those kind of cases we can lean on the work our friends at [troubleshoot.sh](https://troubleshoot.sh) have done.
+In these cases, use the work provided by [troubleshoot.sh](https://troubleshoot.sh).
 
-With troubleshoot tool you can essentially take a dump of the cluster state and share it with other people. You can even use [sbctl](https://github.com/replicatedhq/sbctl) tool to make the dump tarball to act as Kubernetes API.
+The troubleshoot tool can produce a dump of the cluster state for sharing. The [sbctl](https://github.com/replicatedhq/sbctl) tool can expose the dump tarball as a Kubernetes API.
 
-Let's look at how this works with k0s.
+The following example shows how this works with k0s.
 
 ## Setting up
 
-To gather all the needed data we need another tool called [`support-bundle`](https://troubleshoot.sh/docs/support-bundle/introduction/).
+To gather all the needed data, install another tool called [`support-bundle`](https://troubleshoot.sh/docs/support-bundle/introduction/).
 
-You can download it from the [releases page](https://github.com/replicatedhq/troubleshoot/releases), pay attention that you download the right architecture.
+Download it from the [releases page](https://github.com/replicatedhq/troubleshoot/releases). Ensure the correct architecture is selected.
 
 ## Creating support bundle
 
 A Support Bundle needs to know what to collect and optionally, what to analyze. This is defined in a YAML file.
 
-While you can customize the data collection and analysis for your specific needs, we've made a good reference for k0s. These cover the core k0s things like:
+While data collection can be customized, the reference configuration for k0s covers core elements such as:
 
 - collecting info on the host
 - collecting system component statuses from `kube-system` namespace
@@ -27,18 +27,18 @@ While you can customize the data collection and analysis for your specific needs
 - collecting k0s logs
 - checking status of firewalls, anti-virus etc. services which are known to interfere with Kubernetes
 
-As we need to collect host level info you should run the commands on the hosts directly, on controllers and/or workers.
+Because host-level information is required, run the commands directly on controllers and workers.
 
-To get a support bundle, after setting up the [tooling](#setting-up), you simply run:
+After setting up the [tooling](#setting-up), run the following command to generate a support bundle:
 
 ```shell
 support-bundle --kubeconfig /var/lib/k0s/pki/admin.conf https://docs.k0sproject.io/stable/support-bundle-<role>.yaml
 ```
 
-Above `<role>` refers to either `controller`or `worker`. For different roles we collect different things. If you are running a controller with `--enable-worker` or `--single`, where it becomes also a worker, you can also get a combined dump:
+Above `<role>` refers to either `controller` or `worker`. Different roles require different information. When running a controller with `--enable-worker` or `--single`, which also makes it a worker, capture a combined dump:
 
 ```shell
 support-bundle --kubeconfig /var/lib/k0s/pki/admin.conf https://docs.k0sproject.io/stable/support-bundle-controller.yaml https://docs.k0sproject.io/stable/support-bundle-worker.yaml
 ```
 
-Once the data collection and analysis finishes you will get a file called like `support-bundle-<timestamp>.tar.gz`. The file contains all the collected info which you can share with other people.
+After data collection and analysis complete, a file named `support-bundle-<timestamp>.tar.gz` appears. Share this file as needed.


### PR DESCRIPTION
## Summary
- reword docs to remove second-person phrasing
- clarify instructions around support tools
- avoid passive language in troubleshooting docs

## Testing
- `pip install --disable-pip-version-check -r docs/requirements.txt`
- `make docs` *(fails: gh: No such file or directory)*
- `make lint-go` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870be327fa883259982a4839c068700